### PR TITLE
Make navigation translatable.

### DIFF
--- a/cypress/integration/Languages.feature
+++ b/cypress/integration/Languages.feature
@@ -6,8 +6,10 @@ Feature: Languages
   Scenario: English is the default language
     Given a user visits the home page
     Then the page title should read "Welcome"
+    And the main navigation should contain "Home"
 
   Scenario: Switch the language
     Given a user visits the home page
     When the user uses the language switcher to change the site language to "Deutsch"
     Then the page title should read "Willkommen"
+    And the main navigation should contain "Startseite"

--- a/cypress/integration/ui/Languages/index.js
+++ b/cypress/integration/ui/Languages/index.js
@@ -8,6 +8,10 @@ Then(/^the page title should read "([^"]*)"$/, function(title) {
   cy.get('h1').contains(title);
 });
 
+Then(/^the main navigation should contain "([^"]*)"$/, function(title) {
+  cy.get('nav > h2#navigation ~ ul').contains(title);
+});
+
 When(
   /^the user uses the language switcher to change the site language to "([^"]*)"$/,
   function(lang) {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,7 +15,11 @@ module.exports = {
     navigation: [
       { path: '/', label: 'Home', description: 'Navigate to the home page' },
       { path: '/films', label: 'Films', description: 'Film listing' },
-      { path: '/persons', label: 'Persons', description: 'Character listing' },
+      {
+        path: '/persons',
+        label: 'Characters',
+        description: 'Character listing',
+      },
     ],
   },
   plugins: [

--- a/i18n.js
+++ b/i18n.js
@@ -8,12 +8,14 @@ const resources = {
   de: {
     translation: {
       'Star Wars Database': 'Star Wars Datenbank',
+      'Home': 'Startseite',
       'Films': 'Filme',
-      'Films with "{{name}}"': 'Filme mit "{{name}}"',
-      'Characters in "{{title}}"': 'Charaktere in "{{title}}"',
+      'Characters': 'Charaktere',
       'Welcome': 'Willkommen',
       'This is a Gatsby example project.':
         'Das ist ein beispielhaftes Gatsby Projekt.',
+      'Characters in "{{title}}"': 'Charaktere in "{{title}}"',
+      'Films with "{{name}}"': 'Filme mit "{{name}}"',
     },
   },
 };

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -48,7 +48,14 @@ export const Navigation: React.FC<{
   const { t } = useTranslation();
 
   return items.length ? (
-    <div className="page-centered bg-amazee-dark text-white py-2 sm:py-0">
+    <nav
+      role="navigation"
+      aria-labelledby="navigation"
+      className="page-centered bg-amazee-dark text-white py-2 sm:py-0"
+    >
+      <h2 id="navigation" className="sr-only">
+        Main navigation
+      </h2>
       <select
         className="sm:hidden block appearance-none w-full bg-amazee-dark border-2 border-amazee-yellow px-3 py-2"
         onChange={event => localizedNavigate(event.target.value)}
@@ -77,7 +84,7 @@ export const Navigation: React.FC<{
           </li>
         ))}
       </ul>
-    </div>
+    </nav>
   ) : null;
 };
 

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
+import { useTranslation } from 'react-i18next';
 import { LocalizedLink, localizedNavigate } from '../../utils/localized-link';
 import classnames from 'classnames';
 import { useCurrentPath } from '../../hooks/current_path';
@@ -43,16 +44,18 @@ export const Navigation: React.FC<{
    * The current page path.
    */
   currentPath: string;
-}> = ({ items, currentPath }) =>
-  items.length ? (
+}> = ({ items, currentPath }) => {
+  const { t } = useTranslation();
+
+  return items.length ? (
     <div className="page-centered bg-amazee-dark text-white py-2 sm:py-0">
       <select
-        className=" sm:hidden block appearance-none w-full bg-amazee-dark border-2 border-amazee-yellow px-3 py-2"
+        className="sm:hidden block appearance-none w-full bg-amazee-dark border-2 border-amazee-yellow px-3 py-2"
         onChange={event => localizedNavigate(event.target.value)}
       >
         {items.map(item => (
           <option key={item.path} value={item.path}>
-            {item.label}
+            {t(item.label)}
           </option>
         ))}
       </select>
@@ -69,13 +72,14 @@ export const Navigation: React.FC<{
                 }
               )}`}
             >
-              {item.label}
+              {t(item.label)}
             </LocalizedLink>
           </li>
         ))}
       </ul>
     </div>
   ) : null;
+};
 
 export const StaticNavigation: React.FC = () => {
   const currentPath = useCurrentPath();


### PR DESCRIPTION
I'm pretty sure we don't need to follow the same rules as Drupal does for its `t()` function.

So, using `t(item.label)` should be fine, right?