### PR TITLE
Remove title attribute description from navigation links.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,12 +13,11 @@ module.exports = {
   siteMetadata: {
     // TODO: Adjust the static site navigation or remove it entirely.
     navigation: [
-      { path: '/', label: 'Home', description: 'Navigate to the home page' },
-      { path: '/films', label: 'Films', description: 'Film listing' },
+      { path: '/', label: 'Home' },
+      { path: '/films', label: 'Films' },
       {
         path: '/persons',
         label: 'Characters',
-        description: 'Character listing',
       },
     ],
   },

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -34,10 +34,6 @@ export const Navigation: React.FC<{
      * The path to navigate to.
      */
     path: string;
-    /**
-     * A brief description of the target page. Displayed on hover.
-     */
-    description: string;
   }[];
 
   /**
@@ -71,7 +67,6 @@ export const Navigation: React.FC<{
           <li key={item.path}>
             <LocalizedLink
               to={item.path}
-              title={item.description}
               className={`block mx-5 first:ml-0 py-2 hover:text-amazee-yellow border-solid border-b-4 ${classnames(
                 {
                   'border-amazee-dark': !isSubPathOf(currentPath, item.path),
@@ -100,7 +95,6 @@ export const StaticNavigation: React.FC = () => {
       siteMetadata: {
         navigation: {
           path: string;
-          description: string;
           label: string;
         }[];
       };
@@ -110,7 +104,6 @@ export const StaticNavigation: React.FC = () => {
       site {
         siteMetadata {
           navigation {
-            description
             label
             path
           }


### PR DESCRIPTION
Using a `title` attribute on a link is actually bad accessibility because it is, at best, redundant with the link text. At worst, verbose and unhelpful text as the example that is being deleted is; e.g. `Navigate to the home page` is condescending because it implies users don't know how to use web pages.