### PR TITLE
Format TypeScript files with Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,tsx,json,md}\"",
-    "format:check": "prettier --check \"**/*.{js,jsx,tsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "lint": "eslint '*/**/*.{js,ts,tsx}'",
     "serve": "gatsby serve",
     "mock:swapi": "ts-node mocks/swapi.ts",

--- a/src/components/languages/__tests__/languages.spec.ts
+++ b/src/components/languages/__tests__/languages.spec.ts
@@ -1,7 +1,6 @@
 import { delocalizePath, localizePath } from '../languages';
 
 describe('localizePath', () => {
-
   it('does not add prefixes for the default language', () => {
     expect(localizePath('/', 'en', 'en', 'en')).toEqual('/');
     expect(localizePath('/a', 'en', 'en', 'en')).toEqual('/a');


### PR DESCRIPTION
For some reason, we weren't formatting `.ts` files with Prettier. Only `.tsx` files.