### PR TITLE
Typescript updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     es6: true,
     node: true,
   },
-  ignorePatterns: ['cypress', 'public'],
+  ignorePatterns: ['cypress', 'public', 'storybook-static'],
   settings: {
     react: {
       version: 'detect',

--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,5 +1,4 @@
 // Make sure the global stylesheet is added to the gatsby build.
 import '!style-loader!css-loader!postcss-loader!./src/styles/tailwind.css';
 
-// Export the central `wrapRootElement` function.
-export { wrapRootElement } from './src/utils/wrap-root-element';
+export { wrapRootElement } from './src/components/WrapRootElement';

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,42 +1,7 @@
-/**
- * Configure your Gatsby site with this file.
- *
- * See: https://www.gatsbyjs.org/docs/gatsby-config/
- */
+// We register the TypeScript evaluator in gatsby-config so we don't need to do
+// it in any other .js file. It automatically reads TypeScript config from
+// tsconfig.json.
+require('ts-node').register();
 
-require('dotenv').config({ path: `.env` });
-
-// Read in additional environment variables based on the `CURRENT_APP_ENV`
-// environment variable.
-require('dotenv').config({
-  path: `.environments/${process.env.CURRENT_APP_ENV || 'local'}.env`,
-});
-
-module.exports = {
-  siteMetadata: {
-    // TODO: Adjust the static site navigation or remove it entirely.
-    navigation: [
-      { path: '/', label: 'Home' },
-      { path: '/films', label: 'Films' },
-      {
-        path: '/persons',
-        label: 'Characters',
-      },
-    ],
-  },
-  plugins: [
-    'gatsby-plugin-typescript',
-    'gatsby-plugin-layout',
-    'gatsby-plugin-postcss',
-    'gatsby-plugin-react-helmet',
-    // TODO: Update the data source configuration's typeName and fieldName.
-    {
-      resolve: 'gatsby-source-graphql',
-      options: {
-        typeName: 'swapi',
-        fieldName: 'swapi',
-        url: process.env.GATSBY_GRAPHQL_BUILD_ENDPOINT,
-      },
-    },
-  ],
-};
+// Use a TypeScript version of gatsby-config.js.
+module.exports = require('./gatsby-config.ts');

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,0 +1,43 @@
+/**
+ * Configure your Gatsby site with this file.
+ *
+ * See: https://www.gatsbyjs.org/docs/gatsby-config/
+ */
+
+import { config as dotenvConfig } from 'dotenv';
+
+dotenvConfig({ path: `.env` });
+
+// Read in additional environment variables based on the `CURRENT_APP_ENV`
+// environment variable.
+dotenvConfig({
+  path: `.environments/${process.env.CURRENT_APP_ENV || 'local'}.env`,
+});
+
+export const siteMetadata = {
+  // TODO: Adjust the static site navigation or remove it entirely.
+  navigation: [
+    { path: '/', label: 'Home' },
+    { path: '/films', label: 'Films' },
+    {
+      path: '/persons',
+      label: 'Characters',
+    },
+  ],
+};
+
+export const plugins = [
+  'gatsby-plugin-typescript',
+  'gatsby-plugin-layout',
+  'gatsby-plugin-postcss',
+  'gatsby-plugin-react-helmet',
+  // TODO: Update the data source configuration's typeName and fieldName.
+  {
+    resolve: 'gatsby-source-graphql',
+    options: {
+      typeName: 'swapi',
+      fieldName: 'swapi',
+      url: process.env.GATSBY_GRAPHQL_BUILD_ENDPOINT,
+    },
+  },
+];

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,3 @@
-require('ts-node').register();
 const path = require(`path`);
 const { languages, defaultLanguage } = require('./src/utils/languages');
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,2 +1,0 @@
-// Export the central `wrapRootElement` function.
-export { wrapRootElement } from './src/utils/wrap-root-element';

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -1,0 +1,1 @@
+export { wrapRootElement } from './src/components/WrapRootElement';

--- a/src/components/WrapRootElement/index.tsx
+++ b/src/components/WrapRootElement/index.tsx
@@ -3,7 +3,13 @@ import { ApolloProvider } from '@apollo/react-hooks';
 import ApolloClient from 'apollo-boost';
 import fetch from 'isomorphic-fetch';
 
-export const wrapRootElement = ({ element }: { element: ReactNode }) => {
+/**
+ * This component is used by gatsby-browser.ts and gatsby-ssr.ts to add an
+ * Apollo Provider to the app.
+ */
+export const wrapRootElement: React.FC<{ element: ReactNode }> = ({
+  element,
+}) => {
   // TODO: Remove or replace the Apollo client information.
   // The Apollo client and wrapping provider are necessary for loading dynamic
   // data in the browser. If the site is completely static the wrapping provider

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "typeRoots": ["./types", "./node_modules/@types"],
     "sourceMap": true
   },
-  "include": [".storybook", "src", "mocks"]
+  "include": [".storybook", "src", "mocks", "types"]
 }


### PR DESCRIPTION
Does not fix #38 , but gets closer to it. The `gatsby-node.js` conversion is going to require #41 and possible #23.