### PR TITLE
fix(css): fix FOUC due to wrong css file inclusion

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,4 +1,4 @@
 // Make sure the global stylesheet is added to the gatsby build.
-import '!style-loader!css-loader!postcss-loader!./src/assets/styles/tailwind.css';
+import './src/assets/styles/tailwind.css';
 
 export { wrapRootElement } from './src/components/global/WrapRootElement';


### PR DESCRIPTION
Removed the explicit preprocessor when including `tailwind.css`. They cause Gatsby to add them via javascript which causes the FOUC.